### PR TITLE
Have the mutable store just act on a underlying immutable store

### DIFF
--- a/src/cljkv/immutable_store.clj
+++ b/src/cljkv/immutable_store.clj
@@ -1,0 +1,32 @@
+(ns cljkv.immutable-store)
+
+(defn insert
+  "Insert a key into the datastore and return a new copy of it"
+  ([store key value]
+   (assoc store key {:val value}))
+  ([store key value ttl-ms]
+   (assoc store key {:val value
+                     :ttl (+ (System/currentTimeMillis) ttl-ms)})))
+
+(defn delete [store key]
+  "Delete a key from the store"
+  (dissoc store key))
+
+(defn fetch [store key]
+  "Fetch a key from the store"
+  (when-let [value (get store key)]
+    (get value :val)))
+
+(defn expired? [store key]
+  (if-let [value (get store key)]
+    (if-let [ttl (get value :ttl)]
+      (< ttl (System/currentTimeMillis))
+      false)
+    false))
+
+(defn items [store]
+  (count store))
+
+(defn create-store
+  ([] (clojure.lang.PersistentHashMap/EMPTY))
+  ([seed] seed))

--- a/test/cljkv/core_test.clj
+++ b/test/cljkv/core_test.clj
@@ -31,7 +31,8 @@
       (is (= (cljkv.core/fetch store "e") "f"))))
   (testing "Getting a key with an expired TTL return nil and removes the record"
     (let [store (cljkv.core/create-mutable-store example-data)]
-      (cljkv.core/insert store "e" "f" 0) ; TTL is in 0 seconds, expires right away
+      (cljkv.core/insert store "e" "f" 1)
+      (Thread/sleep 2)
       (is (= (cljkv.core/items store) 3))
       (is (= (cljkv.core/fetch store "e") nil))
       (is (= (cljkv.core/items store) 2))))


### PR DESCRIPTION
Move away from having the Mutable store act on the underlying data structure directly and move that into a set of functions that can manipulate it. That means the Mutable store now only handles mutating the global store.
